### PR TITLE
Support for Apple M1

### DIFF
--- a/.github/workflows/omni.yml
+++ b/.github/workflows/omni.yml
@@ -33,10 +33,16 @@ jobs:
         runs-on: macos-latest
         steps:
             - uses: actions/checkout@v2
-            - uses: jiro4989/setup-nim-action@v1
+            - name: Install Nim
+              uses: asdf-vm/actions/install@v1
               with:
-                  nim-version: 'stable'
-            - run: nimble install -Y
+                  tool_versions: |
+                      nim latest
+            - name: nimble install -Y
+              run: |
+                . "${HOME}/.asdf/asdf.sh"
+                asdf local nim latest
+                nimble install -Y
             - run: nimble test -Y
 
     #Windows does not work well

--- a/.github/workflows/omni.yml
+++ b/.github/workflows/omni.yml
@@ -1,6 +1,20 @@
 name: Omni - Test Suite
 
-on: push
+on:
+    push:
+        paths:
+            - '**/*.nim'
+            - '**/*.nims'
+            - '**/*.cfg'
+            - '**/*.nimble'
+            - '**/*.yml'
+    pull_request:
+        paths:
+            - '**/*.nim'
+            - '**/*.nims'
+            - '**/*.cfg'
+            - '**/*.nimble'
+            - '**/*.yml'
 
 jobs:
     All_Linux:
@@ -16,7 +30,7 @@ jobs:
 
     All_MacOS:
         name: All Tests - MacOS
-        runs-on: macos-latest 
+        runs-on: macos-latest
         steps:
             - uses: actions/checkout@v2
             - uses: jiro4989/setup-nim-action@v1

--- a/config.nims
+++ b/config.nims
@@ -16,7 +16,6 @@
 --linetrace:off
 --debugger:off
 --lineDir:off
---deadCodeElim:on
 --nilchecks:off
 
 #release

--- a/omni.nim
+++ b/omni.nim
@@ -148,14 +148,21 @@ proc omni_single_file(is_multi : bool = false, fileFullPath : string, outName : 
 
     #If architecture == native, also pass the mtune=native flag.
     #If architecture == none, no architecture applied
-    var real_architecture = "--passC:-march=" & $architecture
-    if architecture == "native":
-        real_architecture = real_architecture & " --passC:-mtune=native"
-    #x86_64 / amd64 as aliases for x86-64
-    elif architecture == "x86_64" or architecture == "amd64":
-        real_architecture = "--passC:-march=x86-64"
-    elif architecture == "none":
+
+    var real_architecture = ""
+    if compiler == "clang" and architecture == "native" and hostCPU != "amd64":
+        # clang on various non-x86 platforms doesn't like -march=native
+        # see https://stackoverflow.com/questions/65966969/why-does-march-native-not-work-on-apple-m1
         real_architecture = ""
+    else:
+        real_architecture = "--passC:-march=" & $architecture
+        if architecture == "native":
+            real_architecture = real_architecture & " --passC:-mtune=native"
+        #x86_64 / amd64 as aliases for x86-64
+        elif architecture == "x86_64" or architecture == "amd64":
+            real_architecture = "--passC:-march=x86-64"
+        elif architecture == "none":
+            real_architecture = ""
 
     #Add -d:lto only on Linux and Windows (not working on OSX + Clang yet: https://github.com/nim-lang/Nim/issues/15578)
     var lto = ""

--- a/omni.nim
+++ b/omni.nim
@@ -31,7 +31,9 @@ const
 let version_flag = "Omni - version " & $omni_ver & "\n(c) 2020-2021 Francesco Cameli"
 
 #Path to omni_lang
-const omni_lang_pkg_path = "~/.nimble/pkgs/omni_lang-" & omni_ver & "/omni_lang"
+let nimble_dir = if existsEnv("NIMBLE_DIR"): getEnv("NIMBLE_DIR")
+                 else: "~/.nimble"
+let omni_lang_pkg_path = nimble_dir & "/pkgs/omni_lang-" & omni_ver & "/omni_lang"
 
 #Extension for static lib
 when defined(Linux):

--- a/omni.nim
+++ b/omni.nim
@@ -168,7 +168,7 @@ proc omni_single_file(is_multi : bool = false, fileFullPath : string, outName : 
         "nim c --out:" & output_name & " --app:" & lib_nim & 
         " --gc:none --noMain:on --panics:on --hints:off --checks:off --assertions:off" & 
         " --opt:speed -d:release -d:danger " & lto & " --passC:-fPIC " & real_architecture &
-        " --warning[User]:off --warning[UnusedImport]:off --deadCodeElim:on --colors:off --stdout:on"
+        " --warning[User]:off --warning[UnusedImport]:off --colors:off --stdout:on"
 
     #Fix for -d:lto not working yet on OSX + Clang: https://github.com/nim-lang/Nim/issues/15578
     when defined(MacOSX) or defined(MacOS):


### PR DESCRIPTION
A couple of fixes here that got omni working with my setup:

- clang on Apple M1 would not work with `-march=native`. I have added some logic to account for this. More info: https://stackoverflow.com/questions/65966969/why-does-march-native-not-work-on-apple-m1.
- Respect the `NIMBLE_DIR` environment variable which overrides `~/.nimble`. This is important when using omni with a nim compiler installed via [asdf-nim](https://github.com/asdf-community/asdf-nim).
- Nim was complaining about `--deadCodeElim` being deprecated. I checked, and this behavior is always on since [nim 0.19](https://github.com/nim-lang/Nim/blob/dbf8d0b8946419311ac710b1adc995ad206b52c1/changelogs/changelog_0_19_0.md#compiler-changes). Omni requires nim >= 1.4, so I have removed `--deadCodeElim`.

I've also updated the Github Actions workflow:
- Tests will now run when a pull request is submitted.
- The "All Tests - MacOS" job now uses [asdf-nim](https://github.com/asdf-community/asdf-nim), which reduces the build time from ~6 mins to under 2 mins. Example run: https://github.com/elijahr/omni/actions/runs/1624914076